### PR TITLE
Get-TBSnapshot/Get-TBMonitorResult: Support for retrieving errorDetails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the TenantBaseline module will be documented in this file
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+### Fixed
+
+- Property `errorDetails` is not returned by the TCM API by default, so applied
+  `$select` to `Get-TBMonitorResult` and `Get-TBSnapshot` to include it in the
+  responses
+
 ## [0.3.0] - 2026-02-25
 
 ### Added

--- a/src/TenantBaseline/Public/Monitor/Get-TBMonitorResult.ps1
+++ b/src/TenantBaseline/Public/Monitor/Get-TBMonitorResult.ps1
@@ -31,6 +31,11 @@ function Get-TBMonitorResult {
 
         $queryParams = [System.Collections.ArrayList]::new()
 
+        $selectProperties = "`$select=id,monitorId,tenantId,runStatus," + `
+            "runInitiationDateTime,runCompletionDateTime,driftsCount," + `
+            "errorDetails"
+        $queryParams.Add($selectProperties)
+
         if ($MonitorId) {
             $null = $queryParams.Add("`$filter=monitorId eq '$MonitorId'")
         }
@@ -39,9 +44,7 @@ function Get-TBMonitorResult {
             $null = $queryParams.Add("`$top=$Top")
         }
 
-        if ($queryParams.Count -gt 0) {
-            $uri = '{0}?{1}' -f $uri, ($queryParams -join '&')
-        }
+        $uri = '{0}?{1}' -f $uri, ($queryParams -join '&')
 
         Write-TBLog -Message ('Getting monitor results: {0}' -f $uri)
         $items = Invoke-TBGraphPagedRequest -Uri $uri

--- a/src/TenantBaseline/Public/Snapshot/Get-TBSnapshot.ps1
+++ b/src/TenantBaseline/Public/Snapshot/Get-TBSnapshot.ps1
@@ -23,15 +23,20 @@ function Get-TBSnapshot {
 
     process {
         $baseUri = Get-TBApiBaseUri
+        $selectProperties = "?select=completedDateTime,createdBy," + `
+            "createdDateTime,description,displayName,errorDetails,id," + `
+            "resourceLocation,resources,status,tenantId"
 
         if ($SnapshotId) {
-            $uri = '{0}/configurationSnapshotJobs/{1}' -f $baseUri, $SnapshotId
+            $uri = '{0}/configurationSnapshotJobs/{1}{2}' -f $baseUri,
+                $SnapshotId, $selectProperties
             Write-TBLog -Message ('Getting snapshot: {0}' -f $SnapshotId)
             $response = Invoke-TBGraphRequest -Uri $uri -Method 'GET'
             return ConvertFrom-TBSnapshotResponse -Response $response
         }
         else {
-            $uri = '{0}/configurationSnapshotJobs' -f $baseUri
+            $uri = '{0}/configurationSnapshotJobs{1}' -f $baseUri,
+                $selectProperties
             Write-TBLog -Message 'Listing all snapshots'
             $items = Invoke-TBGraphPagedRequest -Uri $uri
 


### PR DESCRIPTION
This PR adds support for retrieving *errorDetails* (which is not populated by default) on *Get-TBSnapshot* by calling it with a select, all other properties are added to the select in order to not lose any of them.

EDIT: Similar fix applied also to *Get-TBMonitorResult*

This fixes the issue #3 I just raised.