### PR TITLE
Add check for mId in baseline resources

### DIFF
--- a/src/TenantBaseline/Public/Report/New-TBDashboard.ps1
+++ b/src/TenantBaseline/Public/Report/New-TBDashboard.ps1
@@ -734,30 +734,32 @@ $styleTokens
                 // Baseline resources
                 for (var j = 0; j < baselines.length; j++) {
                     var bl = baselines[j];
-                    var resources = prop(bl, 'Resources') || prop(bl, 'resources') || [];
-                    if (resources.length > 0) {
-                        var expHeader = textEl('div', 'Baseline Resources (' + resources.length + ')', 'expandable-header');
-                        expHeader.addEventListener('click', function() {
-                            this.classList.toggle('expanded');
-                            var content = this.nextElementSibling;
-                            if (content) content.classList.toggle('expanded');
-                        });
-                        card.appendChild(expHeader);
+                    if (bl.MonitorId === mId){
+                        var resources = prop(bl, 'Resources') || prop(bl, 'resources') || [];
+                        if (resources.length > 0) {
+                            var expHeader = textEl('div', 'Baseline Resources (' + resources.length + ')', 'expandable-header');
+                            expHeader.addEventListener('click', function() {
+                                this.classList.toggle('expanded');
+                                var content = this.nextElementSibling;
+                                if (content) content.classList.toggle('expanded');
+                            });
+                            card.appendChild(expHeader);
 
-                        var expContent = el('div', { className: 'expandable-content' });
-                        var ul = document.createElement('ul');
-                        ul.className = 'resource-list';
-                        for (var k = 0; k < resources.length; k++) {
-                            var resName = prop(resources[k], 'displayName') || prop(resources[k], 'DisplayName') || '';
-                            var resType = prop(resources[k], 'resourceType') || prop(resources[k], 'ResourceType') || '';
-                            var li = document.createElement('li');
-                            li.appendChild(textEl('strong', resName));
-                            li.appendChild(document.createTextNode(' (' + resType + ')'));
-                            ul.appendChild(li);
+                            var expContent = el('div', { className: 'expandable-content' });
+                            var ul = document.createElement('ul');
+                            ul.className = 'resource-list';
+                            for (var k = 0; k < resources.length; k++) {
+                                var resName = prop(resources[k], 'displayName') || prop(resources[k], 'DisplayName') || '';
+                                var resType = prop(resources[k], 'resourceType') || prop(resources[k], 'ResourceType') || '';
+                                var li = document.createElement('li');
+                                li.appendChild(textEl('strong', resName));
+                                li.appendChild(document.createTextNode(' (' + resType + ')'));
+                                ul.appendChild(li);
+                            }
+                            expContent.appendChild(ul);
+                            card.appendChild(expContent);
+                            break;
                         }
-                        expContent.appendChild(ul);
-                        card.appendChild(expContent);
-                        break;
                     }
                 }
 


### PR DESCRIPTION
solves #8 

Changes the behavior of the baseline resources section of the monitor details tab to first check `bl`'s `MonitorId` to see if it matches the current monitor's `mId`, which prevents every monitor card from obtaining the resources associated with `baselines[0]`.